### PR TITLE
Add base docker-compose file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+# Placeholder environment variables

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 This repository is intended as a Django + Golang + React starter project. All pull requests must include unit tests for any new functionality. Keep the instructions and tooling easy for an LLM to follow.
 
+A stub `docker-compose.yml` defines the following services connected by the `app-network`:
+- `service.api` (Django backend)
+- `service.ws` (Golang WebSocket service)
+- `client.web` (React frontend)
+- `infra.postgres` (PostgreSQL)
+
+The stack reads environment variables from `.env`.
+
 ## Testing
 
 - Python unit tests are run with `pytest`.
@@ -12,4 +20,3 @@ This repository is intended as a Django + Golang + React starter project. All pu
 ## Documentation
 
 - Keep `README.md` up to date with explanations for project layout and usage instructions.
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
-## Django Golang React Postgres Redis Starter
+# Django Golang React Postgres Redis Starter
 
+This repository holds a very small starter project intended for experiments with Large Language Models (LLMs). All services are kept simple so that LLMs can easily navigate and modify the codebase.
 
+## Services
+
+- **service.api** – Django backend (placeholder)
+- **service.ws** – Golang WebSocket service (placeholder)
+- **client.web** – React frontend (placeholder)
+- **infra.postgres** – PostgreSQL database
+
+A `docker-compose.yml` file is provided with placeholders for these services. Each service connects to a shared network named `app-network` and exposes its development port.
+
+To start the stack once real implementations exist:
+
+```bash
+docker-compose up
+```
+
+Environment variables can be placed in the provided `.env` file.
+
+## Contributing
+
+Keep documentation short and clear so that LLMs can follow it. After modifying code, run the Python, Go and Node test suites as described in `AGENTS.md`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '3.9'
+
+services:
+  # service.api - Django backend
+  service.api:
+    build:
+      context: ./service.api  # placeholder build context
+    ports:
+      - "8000:8000"
+    networks:
+      - app-network
+    env_file:
+      - .env
+
+  # service.ws - Golang WebSocket service
+  service.ws:
+    build:
+      context: ./service.ws  # placeholder build context
+    ports:
+      - "8080:8080"
+    networks:
+      - app-network
+    env_file:
+      - .env
+
+  # client.web - React frontend
+  client.web:
+    build:
+      context: ./client.web  # placeholder build context
+    ports:
+      - "3000:3000"
+    networks:
+      - app-network
+    env_file:
+      - .env
+
+  # infra.postgres - PostgreSQL database
+  infra.postgres:
+    image: postgres:latest  # placeholder image
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - app-network
+    env_file:
+      - .env
+
+volumes:
+  pgdata:
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
## Summary
- add stub `docker-compose.yml` with network and volume definitions
- document how the stack fits together in `README.md`
- update `AGENTS.md` with details about the compose setup
- provide placeholder `.env` file
- rename network to `app-network`

## Testing
- `pytest`
- `go test ./...` *(fails: directory prefix . does not contain main module)*
- `npm test` *(fails: no `package.json` present)*

------
https://chatgpt.com/codex/tasks/task_e_684d2dc1ac24832e96fd3a4980ff11eb