### PR TITLE
Add docker-compose build check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ The stack reads environment variables from `.env`.
 - Golang unit tests are run with `go test ./...`.
 - React/Node unit tests are run with `npm test --silent`.
 - Run all relevant test suites after making changes and before committing. If a test command fails because dependencies are missing, mention this in the PR as required by the main instructions.
+- Confirm the Docker Compose stack builds successfully with `docker compose build`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A `docker-compose.yml` file is provided with placeholders for these services. Ea
 To start the stack once real implementations exist:
 
 ```bash
+docker compose build
 docker-compose up
 ```
 


### PR DESCRIPTION
## Summary
- require building the Docker Compose stack in `AGENTS.md`
- document Docker Compose build step in the README

## Testing
- `pytest -q` *(no tests found)*
- `go test ./...` *(fails: missing go.sum entry)*
- `npm test --silent` *(fails: vitest not found)*
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dae1753c8832ea2e2a9159fda2799