### PR TITLE
Fix Go module and React tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ launches the Vite dev server on <http://localhost:3000>. For production builds
 the multi-stage `Dockerfile` compiles the app and serves the `build/` directory
 with Nginx. Requests to `/api/` are proxied to the Django backend.
 
-Run the frontend unit tests with:
+Run the frontend unit tests with Vitest using the jsdom environment:
 
 ```bash
 cd client/web

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -7,17 +7,18 @@
     "build": "vite build",
     "preview": "vite preview",
     "start": "vite",
-    "test": "vitest"
+    "test": "vitest --environment jsdom"
   },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.0.0",
     "@vitejs/plugin-react": "^4.0.0",
+    "jsdom": "^24.0.0",
     "vite": "^5.0.0",
-    "vitest": "^1.5.0",
-    "jsdom": "^24.0.0"
+    "vitest": "^1.5.0"
   }
 }

--- a/client/web/src/App.test.jsx
+++ b/client/web/src/App.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
 import React from 'react';
 import App from './App';
 import { describe, it, expect } from 'vitest';

--- a/service/ws/go.sum
+++ b/service/ws/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=


### PR DESCRIPTION
## Summary
- add missing go.sum for websocket service
- import jest-dom and set jsdom environment for React tests
- note jsdom test environment in README

## Testing
- `pytest -q`
- `go test ./...`
- `npm test --silent`
- `docker compose build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684daf367b34832ea26c9b154c460508