### PR TITLE
Fix client web build directory

### DIFF
--- a/client/web/vite.config.js
+++ b/client/web/vite.config.js
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: 'build'
+  },
   server: {
     port: 3000,
     proxy: {


### PR DESCRIPTION
## Summary
- configure Vite to output to `build/`

## Testing
- `npm test --silent --prefix client/web -- --run`
- `pytest -q service/api`
- `(cd service/ws && go test ./...)`
- `docker compose build` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db9a801d4832e9134f633f07114c4